### PR TITLE
实现DownStream的keep-alive支持

### DIFF
--- a/src/main/java/org/howard1209a/configure/ServerConfiguration.java
+++ b/src/main/java/org/howard1209a/configure/ServerConfiguration.java
@@ -73,7 +73,7 @@ public class ServerConfiguration {
     }
 
     // 使用欧几里得算法计算任意多个数的最大公因子
-    public static int findMultiGCD(int[] numbers) {
+    private static int findMultiGCD(int[] numbers) {
         if (numbers.length < 2) {
             return numbers[0];
         }

--- a/src/main/java/org/howard1209a/configure/pojo/Downstream.java
+++ b/src/main/java/org/howard1209a/configure/pojo/Downstream.java
@@ -1,0 +1,13 @@
+package org.howard1209a.configure.pojo;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class Downstream {
+    private Integer timeout;
+    private Integer max;
+}

--- a/src/main/java/org/howard1209a/configure/pojo/Gateway.java
+++ b/src/main/java/org/howard1209a/configure/pojo/Gateway.java
@@ -10,6 +10,7 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 public class Gateway {
+    private Protocal protocol;
     private List<Route> routes;
 
     public Route matchRoute(String uri) {

--- a/src/main/java/org/howard1209a/configure/pojo/Protocal.java
+++ b/src/main/java/org/howard1209a/configure/pojo/Protocal.java
@@ -1,0 +1,12 @@
+package org.howard1209a.configure.pojo;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class Protocal {
+    private Downstream downstream;
+}

--- a/src/main/java/org/howard1209a/server/KeepaliveManager.java
+++ b/src/main/java/org/howard1209a/server/KeepaliveManager.java
@@ -1,0 +1,80 @@
+package org.howard1209a.server;
+
+import io.netty.channel.Channel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.howard1209a.configure.ServerConfiguration;
+import org.howard1209a.configure.pojo.Downstream;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+public class KeepaliveManager {
+    private static final KeepaliveManager MANAGER = new KeepaliveManager();
+
+    private ConcurrentHashMap<Channel, KeepaliveState> cache;
+
+    private KeepaliveManager() {
+        cache = new ConcurrentHashMap<>();
+    }
+
+    public static KeepaliveManager getInstance() {
+        return MANAGER;
+    }
+
+    public void register(Channel channel) {
+        Downstream downstream = ServerConfiguration.getInfo().getProtocol().getDownstream();
+        KeepaliveState keepaliveState = new KeepaliveState(channel, downstream.getTimeout(), 0, downstream.getMax());
+        cache.put(channel, keepaliveState);
+    }
+
+    public KeepaliveState get(Channel channel) {
+        return cache.get(channel);
+    }
+
+    public void remove(Channel channel) {
+        cache.remove(channel);
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class KeepaliveState {
+        private Channel channel;
+        private Integer timeout;
+        private Integer currentNum;
+        private Integer maxNum;
+
+        public boolean isArriveMax() {
+            return currentNum.compareTo(maxNum - 1) == 0;
+        }
+
+        public void increment() {
+            currentNum++;
+        }
+    }
+
+    public static class TimeoutCheck implements Runnable {
+        private Channel checkedChannel;
+        private int lastNum;
+
+        public TimeoutCheck(Channel checkedChannel) {
+            this.checkedChannel = checkedChannel;
+            this.lastNum = 1;
+        }
+
+        @Override
+        public void run() {
+            KeepaliveState keepaliveState = MANAGER.get(checkedChannel);
+            if (keepaliveState.getCurrentNum() == lastNum) {
+                checkedChannel.flush();
+                checkedChannel.close();
+                return;
+            }
+            Integer timeout = ServerConfiguration.getInfo().getProtocol().getDownstream().getTimeout();
+            lastNum = keepaliveState.currentNum;
+            checkedChannel.eventLoop().schedule(this, timeout, TimeUnit.SECONDS);
+        }
+    }
+}

--- a/src/main/java/org/howard1209a/server/Server.java
+++ b/src/main/java/org/howard1209a/server/Server.java
@@ -7,9 +7,7 @@ import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
-import io.netty.handler.codec.http.HttpClientCodec;
-import io.netty.handler.codec.http.HttpRequest;
-import io.netty.handler.codec.http.HttpServerCodec;
+import io.netty.handler.codec.http.*;
 import io.netty.handler.logging.LoggingHandler;
 import lombok.extern.slf4j.Slf4j;
 import org.howard1209a.configure.ServerConfiguration;
@@ -17,9 +15,7 @@ import org.howard1209a.configure.pojo.Route;
 import org.howard1209a.exception.ServerRepeatStartException;
 import org.howard1209a.server.dispatcher.HashDispatcher;
 import org.howard1209a.server.dispatcher.PollingDispatcher;
-import org.howard1209a.server.handler.DispatchHandler;
-import org.howard1209a.server.handler.DistributeHandler;
-import org.howard1209a.server.handler.RouteHandler;
+import org.howard1209a.server.handler.*;
 import org.howard1209a.server.pojo.HttpRequestWrapper;
 
 import java.io.FileNotFoundException;
@@ -47,6 +43,15 @@ public class Server {
                     @Override
                     protected void initChannel(SocketChannel socketChannel) throws Exception {
                         socketChannel.pipeline().addLast(new HttpClientCodec());
+//                        socketChannel.pipeline().addLast(new DistributeHandler());
+//                        socketChannel.pipeline().addLast(new SimpleChannelInboundHandler<HttpObject>() {
+//
+//                            @Override
+//                            protected void channelRead0(ChannelHandlerContext channelHandlerContext, HttpObject httpObject) throws Exception {
+//                                System.out.println("1");
+//                            }
+//                        });
+//                        socketChannel.pipeline().addLast(new MyResponseHandler());
                         socketChannel.pipeline().addLast(new DistributeHandler());
                     }
                 });
@@ -66,6 +71,7 @@ public class Server {
                     protected void initChannel(NioSocketChannel nioSocketChannel) throws Exception {
                         nioSocketChannel.pipeline().addLast(new HttpServerCodec());
                         nioSocketChannel.pipeline().addLast(new RouteHandler());
+                        nioSocketChannel.pipeline().addLast(new HeaderHandler());
                         nioSocketChannel.pipeline().addLast(new DispatchHandler(hashDispatcher));
                     }
                 })

--- a/src/main/java/org/howard1209a/server/handler/DistributeHandler.java
+++ b/src/main/java/org/howard1209a/server/handler/DistributeHandler.java
@@ -1,19 +1,81 @@
 package org.howard1209a.server.handler;
 
+import io.netty.buffer.Unpooled;
 import io.netty.channel.*;
-import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.*;
+import io.netty.util.CharsetUtil;
+import org.howard1209a.configure.ServerConfiguration;
+import org.howard1209a.server.KeepaliveManager;
 import org.howard1209a.server.StreamManager;
 
-public class DistributeHandler extends SimpleChannelInboundHandler<HttpResponse> {
+import java.util.concurrent.TimeUnit;
+
+public class DistributeHandler extends SimpleChannelInboundHandler<HttpObject> {
+    private HttpResponse httpResponse;
+    private StringBuilder responseData = new StringBuilder();
 
     @Override
-    protected void channelRead0(ChannelHandlerContext channelHandlerContext, HttpResponse httpResponse) throws Exception {
-        Channel upStreamChannel = channelHandlerContext.channel();
-        Channel downStreamChannel = StreamManager.getInstance().get(upStreamChannel);
-        StreamManager.getInstance().remove(upStreamChannel);
-        upStreamChannel.close();
+    protected void channelRead0(ChannelHandlerContext channelHandlerContext, HttpObject msg) throws Exception {
+        if (msg instanceof HttpResponse) {
+            // 接收本次响应头部信息
+            httpResponse = (HttpResponse) msg;
+        } else if (msg instanceof HttpContent) {
+            // 接收本次响应体数据
+            HttpContent httpContent = (HttpContent) msg;
+            responseData.append(httpContent.content().toString(CharsetUtil.UTF_8));
 
-        ChannelFuture distributeFuture = downStreamChannel.writeAndFlush(httpResponse);
+            // 如果是 LastHttpContent，表示响应结束
+            if (msg instanceof LastHttpContent) {
+                Channel upStreamChannel = channelHandlerContext.channel();
+                Channel downStreamChannel = StreamManager.getInstance().get(upStreamChannel);
+                StreamManager.getInstance().remove(upStreamChannel);
+                upStreamChannel.close();
+
+                String fullResponseData = responseData.toString();
+                FullHttpResponse response = generateResponse(httpResponse, fullResponseData);
+
+                KeepaliveManager keepaliveManager = KeepaliveManager.getInstance();
+                KeepaliveManager.KeepaliveState keepaliveState = keepaliveManager.get(downStreamChannel);
+                if (keepaliveState != null) {
+                    response.headers().add("Connection", "keep-alive");
+                }
+                ChannelFuture distributeFuture = downStreamChannel.writeAndFlush(response);
+                if (keepaliveState != null) {
+                    if (keepaliveState.getCurrentNum() == 0) {
+                        Integer timeout = ServerConfiguration.getInfo().getProtocol().getDownstream().getTimeout();
+                        downStreamChannel.eventLoop().schedule(new KeepaliveManager.TimeoutCheck(downStreamChannel), timeout, TimeUnit.SECONDS);
+                    }
+                    if (keepaliveState.isArriveMax()) {
+                        keepaliveManager.remove(downStreamChannel);
+                        closeDownStreamChannel(distributeFuture);
+                    } else {
+                        keepaliveState.increment();
+                    }
+                } else {
+                    closeDownStreamChannel(distributeFuture);
+                }
+
+                // 清空 responseData 以便接收下一个响应
+                responseData.setLength(0);
+                httpResponse = null;
+            }
+        }
+    }
+
+    private FullHttpResponse generateResponse(HttpResponse response, String responseData) {
+        FullHttpResponse newResponse = new DefaultFullHttpResponse(
+                response.protocolVersion(),
+                response.status(),
+                Unpooled.copiedBuffer(responseData, CharsetUtil.UTF_8)
+        );
+
+        // 将原始响应头部信息拷贝到新的响应体中
+        newResponse.headers().add(response.headers());
+
+        return newResponse;
+    }
+
+    private void closeDownStreamChannel(ChannelFuture distributeFuture) {
         distributeFuture.addListener(new ChannelFutureListener() {
             @Override
             public void operationComplete(ChannelFuture channelFuture) throws Exception {

--- a/src/main/java/org/howard1209a/server/handler/DistributeHandler.java
+++ b/src/main/java/org/howard1209a/server/handler/DistributeHandler.java
@@ -5,6 +5,7 @@ import io.netty.channel.*;
 import io.netty.handler.codec.http.*;
 import io.netty.util.CharsetUtil;
 import org.howard1209a.configure.ServerConfiguration;
+import org.howard1209a.configure.pojo.Downstream;
 import org.howard1209a.server.KeepaliveManager;
 import org.howard1209a.server.StreamManager;
 
@@ -37,7 +38,10 @@ public class DistributeHandler extends SimpleChannelInboundHandler<HttpObject> {
                 KeepaliveManager keepaliveManager = KeepaliveManager.getInstance();
                 KeepaliveManager.KeepaliveState keepaliveState = keepaliveManager.get(downStreamChannel);
                 if (keepaliveState != null) {
-                    response.headers().add("Connection", "keep-alive");
+                    Downstream downstream = ServerConfiguration.getInfo().getProtocol().getDownstream();
+                    HttpHeaders headers = response.headers();
+                    headers.add("Connection", "keep-alive");
+                    headers.add("Keep-Alive", "timeout=" + downstream.getTimeout() + ", max=" + downstream.getMax());
                 }
                 ChannelFuture distributeFuture = downStreamChannel.writeAndFlush(response);
                 if (keepaliveState != null) {

--- a/src/main/java/org/howard1209a/server/handler/HeaderHandler.java
+++ b/src/main/java/org/howard1209a/server/handler/HeaderHandler.java
@@ -1,0 +1,42 @@
+package org.howard1209a.server.handler;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpVersion;
+import org.howard1209a.server.KeepaliveManager;
+import org.howard1209a.server.pojo.HttpRequestWrapper;
+
+public class HeaderHandler extends ChannelInboundHandlerAdapter {
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        HttpRequestWrapper wrapper = (HttpRequestWrapper) msg;
+        HttpRequest request = wrapper.getRequest();
+
+        processConnectionHeader(request, ctx);
+
+        super.channelRead(ctx, msg);
+    }
+
+    private void processConnectionHeader(HttpRequest request, ChannelHandlerContext ctx) {
+        // 如果是第二次及之后到来的长连接，不做处理
+        KeepaliveManager keepaliveManager = KeepaliveManager.getInstance();
+        if (keepaliveManager.get(ctx.channel()) != null) {
+            return;
+        }
+
+        // 如果是第一次到来的连接，处理
+        HttpHeaders headers = request.headers();
+        String connection = headers.get("Connection");
+        if (connection != null) {
+            if (connection.equals("keep-alive")) {
+                keepaliveManager.register(ctx.channel());
+            }
+        } else {
+            if (request.protocolVersion().equals(HttpVersion.HTTP_1_1)) {
+                keepaliveManager.register(ctx.channel());
+            }
+        }
+    }
+}

--- a/src/main/resources/conf.yaml
+++ b/src/main/resources/conf.yaml
@@ -1,3 +1,7 @@
+protocol:
+  downstream:
+    timeout: 20
+    max: 3
 routes: # 网关路由配置
   - id: static-web
     addresses:

--- a/test.http
+++ b/test.http
@@ -1,5 +1,6 @@
 GET http://localhost:12090/static
 Accept: application/json
+Connection: close
 
 ###
 GET http://localhost:12090/api/item?id=99


### PR DESCRIPTION
### 是否开启下流客户端的keep-alive
客户端如果携带Connection则按Connection来，如果没有携带Connection的header，则http1.0默认关闭，http1.1默认开启。

测试了浏览器和postman，wireshark抓包验证通过。
### 配置
```yml
protocol:
  downstream:
    timeout: 20
    max: 3
```
如上配置等于keep-alive持久连接最多3个请求后关闭，每20s检测一次如果没有新请求就关闭